### PR TITLE
Fix: temporary fix wrong way of setting proxy envs

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -175,7 +175,8 @@ func getProxyValue(proxyType string) (proxyValue string) {
 		return
 	}
 	port := strconv.Itoa(int(childSettings.GetInt(gkeyProxyPort)))
-	proxyValue = fmt.Sprintf("%s://%s:%s", proxyType, host, port)
+	// proxyValue = fmt.Sprintf("%s://%s:%s", proxyType, host, port)
+	proxyValue = fmt.Sprintf("%s:%s", host, port)
 	return
 }
 


### PR DESCRIPTION
Proxy envs NEVER REQUIRE "https://" prefixes. This would NOT work for any applications. Because proxy servers are never accessed this way. And we actually never needed this ugly way of setting it, as we already had per-app proxy built-in in DDE.

Maintainers can reject this PR, as I think you'd never need this. This PR can be accepted, only if this is considered as a good solution after discussing with developers in UnionTech.