### PR TITLE
fix: 修复当声音设置为0时，开关机音效还是会有声音问题。

### DIFF
--- a/sound_effect/wav.c
+++ b/sound_effect/wav.c
@@ -252,14 +252,17 @@ int wav_convert(char *file_name,char *dest_name,float precent){
         return -1;
     }
 
-    //int db = -4;
-    int db = wav_getdb(precent);
-    printf("db: %d.\n",db);
+    double factor = 0.0;
+    if (precent > 0.00){
+        //int db = -4;
+        int db = wav_getdb(precent);
+        printf("db: %d.\n",db);
 
-    //注意：pow里必须强转为double类型，因为两个int类型做除法，结果还是int类型，会损失精度，此处把db强转为
-    //double，double/int最后的结果是个double，保证了精度
-    double factor = pow(10, (double)db / 20);
-
+        //注意：pow里必须强转为double类型，因为两个int类型做除法，结果还是int类型，会损失精度，此处把db强转为
+        //double，double/int最后的结果是个double，保证了精度
+        factor= pow(10, (double)db / 20);
+    }
+   
     wav = (wav_t *)malloc(sizeof(wav_t));
     if(NULL == wav){
         printf("malloc wav failedly\n");


### PR DESCRIPTION
音量设置为0，设置到音频文件中的音量，未能设置为0,导致还有声音输出。

Log: 修复当声音设置为0时，开关机音效还是会有声音问题。
Influence: 开关机音效音量设置
Bug: https://pms.uniontech.com/bug-view-126309.html