### PR TITLE
fix: test failure when sh is bash

### DIFF
--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestEncode(t *testing.T) {
-	_, err := exec.LookPath("sh")
+	_, err := exec.LookPath("dash")
 	if err != nil {
-		t.Skip("not found sh")
+		t.Skip("dash not found")
 	}
 
 	for _, s := range []string{
@@ -21,7 +21,7 @@ func TestEncode(t *testing.T) {
 		r := Encode(s)
 		t.Log(r)
 
-		cmd := exec.Command("sh", "-c", "echo -n "+r)
+		cmd := exec.Command("dash", "-c", "echo -n "+r)
 		output, err := cmd.Output()
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
`echo` is a shell built-in and behaves differently on bash and dash. The test currently passes with dash but fails with bash. Let's use dash explicitly here.

Log: Fix test failure when sh is bash