### PR TITLE
fix(audio): Only drop the stream when there is a hole (length > 0)

### DIFF
--- a/pulse/meter.c
+++ b/pulse/meter.c
@@ -40,7 +40,10 @@ static void read_callback(pa_stream *s, size_t length, void *userdata) {
     }
 
     if (!data) {
-	pa_stream_drop(s);
+        /* NULL data means either a hole or empty buffer.
+         * Only drop the stream when there is a hole (length > 0) */
+        if (length)
+            pa_stream_drop(s);
 	return;
     }
 


### PR DESCRIPTION
NULL data means either a hole or empty buffer.
Only drop the stream when there is a hole (length > 0)

Log:
Task: https://pms.uniontech.com/task-view-98970.html
Influence: 声音
Change-Id: I3183c816e4431163b959c5353c930464eb470b2a