### PR TITLE
fix: 修复 pa context fail 导致崩溃问题

### DIFF
--- a/pulse/mainloop_callbacks.go
+++ b/pulse/mainloop_callbacks.go
@@ -26,7 +26,7 @@ func startHandleSafeDo() {
 	// Move all safeDo fn to here to avoid creating too many OS Thread.
 	// Because GOMAXPROC only apply to go-runtime.
 	for c := range pendingSafeDo {
-		if c.fn != nil {
+		if c.fn != nil && c.loop != nil {
 			runtime.LockOSThread()
 			C.pa_threaded_mainloop_lock(c.loop)
 			c.fn()


### PR DESCRIPTION
pa context fail 后 dde-session-daemon 会强制生成一个新的 context 旧的 context 会被释放，但异步事件中未处理此情况。

Log:
Bug: https://pms.uniontech.com/bug-view-161563.html
Influence: 无
Change-Id: I242f4c2d6ccacb57cff808f82f5c397895f3bb54