### PR TITLE
fix(audio): 修复音频选择profile错误的问题

### DIFF
--- a/pulse/misc.go
+++ b/pulse/misc.go
@@ -72,18 +72,12 @@ func (infos ProfileInfos2) SelectProfile() string {
 		return ""
 	}
 
-	profile := infos.selectByAvailable(AvailableTypeYes)
+	profile := infos.selectByAvailable()
 	if len(profile.Name) != 0 {
 		return profile.Name
 	}
 
-	profile = infos.selectByAvailable(AvailableTypeUnknow)
-	if len(profile.Name) != 0 {
-		return profile.Name
-	}
-
-	profile = infos.selectByAvailable(AvailableTypeNo)
-	return profile.Name
+	return infos[0].Name
 }
 
 func (infos ProfileInfos2) Len() int {
@@ -98,10 +92,10 @@ func (infos ProfileInfos2) Swap(i, j int) {
 	infos[i], infos[j] = infos[j], infos[i]
 }
 
-func (infos ProfileInfos2) selectByAvailable(available int) ProfileInfo2 {
+func (infos ProfileInfos2) selectByAvailable() ProfileInfo2 {
 	var profile ProfileInfo2
 	for _, info := range infos {
-		if info.Available != available {
+		if info.Available == 0 {
 			continue
 		}
 


### PR DESCRIPTION
根据文档，profile available 的值只有零 和 非零：

Is this profile available? If this is zero, meaning "unavailable", then it makes no sense to try to activate this profile.

If this is non-zero, it's still not a guarantee that activating the profile will result in anything useful, it just means that the server isn't aware of any reason why the profile would definitely be useless.

Log:
Bug: https://pms.uniontech.com/task-view-98970.html
Influence: 无
Change-Id: Ia5071e9ba1cfeb46b9a2fc375b6b069c46b69d31