### PR TITLE
feat: 增加startupNotify名单,强制显示加载状态

### DIFF
--- a/appinfo/desktopappinfo/desktopappinfo.go
+++ b/appinfo/desktopappinfo/desktopappinfo.go
@@ -6,7 +6,9 @@ package desktopappinfo
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -612,6 +614,37 @@ func startCommand(ai *DesktopAppInfo, cmdline string, files []string, launchCont
 
 	var snId string
 	startupNotify := ai.GetStartupNotify()
+	// 名单中的应用强制startupNotify,
+	forceStartupNotifyList := []string{
+		"com.alibabainc.dingtalk.desktop",
+		"com.qq.im.deepin.desktop",
+		"com.qq.weixin.deepin.desktop",
+		"com.qq.weixin.work.deepin.desktop",
+		"wemeetapp.desktop",
+		"wps-office-prometheus.desktop",
+		"cn.codemao.kitten3.desktop",
+		"cn.codemao.wood.desktop",
+		"cn.scratch.scratch.desktop",
+		"com.51dzt.deepin.desktop",
+		"com.macromediaflash8.deepin.desktop",
+		"com.meitu.mtxx.deepin.desktop",
+		"com.mspaint.deepin.desktop",
+		"com.qq.tenvideo.desktop",
+		"com.youku.deepin.desktop",
+		"com.youkuido.deepin.desktop",
+		"gimp.desktop",
+		"mu.codewith.mu-editor.desktop",
+	}
+	const startupNotifyListPath = "/var/lib/apps/startupNotifyList.json"
+	c, err := ioutil.ReadFile(startupNotifyListPath)
+	if err == nil {
+		_ = json.Unmarshal(c, &forceStartupNotifyList)
+	}
+	for _, d := range forceStartupNotifyList {
+		if strings.Contains(ai.GetFileName(), d) {
+			startupNotify = true
+		}
+	}
 	if startupNotify && launchContext != nil &&
 		launchContext.GetTimestamp() != 0 {
 		snId, _ = launchContext.GetStartupNotifyId(ai, files)


### PR DESCRIPTION
go-lib记录默认名单,/var/lib/apps/startupNotifyList.json作为oem名单.如果有oem名单,则oem名单应用优先.名单内应用强制显示加载状态

Log: 增加startupNotify名单,强制显示加载状态
Task: https://pms.uniontech.com/task-view-219109.html
Influence: 应用启动参数
Change-Id: I3b46811228287e27afc3aeadb22561ac49b33952