### PR TITLE
fix: add null check for pa_context operations

### DIFF
--- a/pulse/dde-pulse.c
+++ b/pulse/dde-pulse.c
@@ -59,11 +59,21 @@ pa_context_index_cb_t get_index_cb()
   }                                                                     \
   void _get_##TYPE##_info(pa_threaded_mainloop* loop, pa_context *c, int64_t cookie, uint32_t index) \
   {                                                                     \
-    pa_operation_unref(pa_context_get_##TYPE##_info##PA_FUNC_SUFFIX(c, index, receive_##TYPE##_cb, (void*)cookie)); \
+    pa_operation* o = pa_context_get_##TYPE##_info##PA_FUNC_SUFFIX(c, index, receive_##TYPE##_cb, (void*)cookie); \
+    if (o) {                                                            \
+      pa_operation_unref(o);                                            \
+    } else {                                                            \
+      fprintf(stderr, "Failed to get %s info for index %u\n", #TYPE, index); \
+    }                                                                   \
   }                                                                     \
   void _get_##TYPE##_info_list(pa_threaded_mainloop* loop, pa_context* ctx, int64_t cookie) \
   {                                                                     \
-    pa_operation_unref(pa_context_get_##TYPE##_info_list(ctx, receive_##TYPE##_cb, (void*)cookie)); \
+    pa_operation* o = pa_context_get_##TYPE##_info_list(ctx, receive_##TYPE##_cb, (void*)cookie); \
+    if (o) {                                                            \
+      pa_operation_unref(o);                                            \
+    } else {                                                            \
+      fprintf(stderr, "Failed to get %s info list\n", #TYPE);           \
+    }                                                                   \
   }
 
 DEFINE(PA_SUBSCRIPTION_EVENT_SINK, sink, _by_index);
@@ -85,7 +95,12 @@ void receive_server_info_cb(pa_context *c, const pa_server_info *info, void *use
 }
 void _get_server_info(pa_threaded_mainloop* loop, pa_context *c, int64_t cookie)
 {
-    pa_operation_unref(pa_context_get_server_info(c, receive_server_info_cb, (void*)cookie));
+    pa_operation* o = pa_context_get_server_info(c, receive_server_info_cb, (void*)cookie);
+    if (!o) {
+        fprintf(stderr, "Failed to get server info\n");
+        return;
+    }
+    pa_operation_unref(o);
 }
 
 void dpa_context_subscribe_cb(pa_context *c, pa_subscription_event_type_t t, uint32_t idx, void *userdata)


### PR DESCRIPTION
Added null pointer checks for pa_context operation results to prevent crashes when operations fail. Previously, pa_operation_unref was called directly on the operation result without checking if it was NULL, which could cause segmentation faults when PulseAudio operations failed.

The fix ensures that when pa_context_get_* functions return NULL (indicating operation failure), appropriate error messages are logged instead of dereferencing a null pointer. This addresses crashes that occurred when playing audio after login, likely due to PulseAudio context not being fully ready.

Influence:
1. Test audio playback immediately after login
2. Verify no crashes occur when PulseAudio services are unavailable
3. Check error messages in logs when audio operations fail
4. Test various audio sources and sinks to ensure stability

fix: 为pa_context操作添加空指针检查

添加了对pa_context操作结果的空指针检查，防止操作失败时发生崩溃。之前代码
直接对操作结果调用pa_operation_unref而没有检查是否为NULL，当PulseAudio操 作失败时可能导致段错误。

此修复确保当pa_context_get_*函数返回NULL（表示操作失败）时，会记录适当的
错误信息而不是解引用空指针。这解决了登录后播放音频时发生的崩溃问题，很可
能是由于PulseAudio上下文未完全就绪导致的。
PMS: BUG-334279
Influence:
1. 测试登录后立即播放音频的功能
2. 验证当PulseAudio服务不可用时不会发生崩溃
3. 检查音频操作失败时的错误日志信息
4. 测试各种音频源和接收器以确保稳定性