### PR TITLE
chore: update changelog to 6.0.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+golang-github-linuxdeepin-go-lib (6.0.14) unstable; urgency=medium
+
+  * fix: add null check for pa_context operations (#117)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 05 Feb 2026 19:22:03 +0800
+
 golang-github-linuxdeepin-go-lib (6.0.13) unstable; urgency=medium
 
   * feat: add module unloading functionality (#115)


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.14

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.14
- 目标分支: master
